### PR TITLE
Support for MPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ MKL_DYNAMIC = "FALSE"
 MKL_NUM_THREADS = "1"
 
 [tool.pixi.dependencies]
-mumps-seq = ">=5.8.1,<6"
+mumps-mpi = ">=5.8.1,<6"
 scipy = ">=1.15.2,<2"
 numpy = ">=2.2.6,<3"
 setuptools_scm = ">=8.3.1,<9"
@@ -74,6 +74,7 @@ cython = ">=3.1.1,<4"
 pytest = ">=8.3.5,<9"
 git = ">=2.49.0,<3"
 pkgconfig = ">=1.5.5,<2"
+mpi4py = ">=4.1.0,<5"
 
 [tool.pixi.feature.publish.dependencies]
 uv = ">=0.4.5"

--- a/src/mumps/_mumps.pyx.in
+++ b/src/mumps/_mumps.pyx.in
@@ -99,13 +99,16 @@ cdef class {{p.lower()}}mumps:
 
     cdef PyThread_type_lock lock
 
-    def __cinit__(self, verbose=False, sym=0):
+    def __cinit__(self, verbose=False, sym=0, comm=None):
         self.lock = PyThread_allocate_lock()
 
         self.params.job = -1
         self.params.sym = sym
         self.params.par = 1
-        self.params.comm_fortran = -987654  # MPI_COMM_WORLD, according to docs
+        if comm:
+            self.params.comm_fortran = comm.py2f()
+        else:
+            self.params.comm_fortran = -987654  # MPI_COMM_WORLD, according to docs
 
         with nogil:
             mumps.{{p.lower()}}mumps_c(&self.params)
@@ -117,7 +120,7 @@ cdef class {{p.lower()}}mumps:
         self.rinfo = make_{{p.lower()}}mumps_real_array(self.params.rinfo)
         self.rinfog = make_{{p.lower()}}mumps_real_array(self.params.rinfog)
 
-    def __init__(self, verbose=False, sym=0):
+    def __init__(self, verbose=False, sym=0, comm=None):
         # no diagnostic output (MUMPS is very verbose normally)
         if not verbose:
             self.icntl[1] = 0


### PR DESCRIPTION
solves #1 
This PR shows how to add MPI support to python-mumps
* I added MPI communications in the mumps.Context class
* I made the choice of broadcasting the solution to all procs when running ctx.solve so that all procs got the correct values but it induces some additionnal cost
* I added a test in `test_mumps.py` with a personnal application in electric systems that can easily be scaled to test MPI scaling (I had the use case on the shelf I don't aim at adding it to the test stack of python-mumps)
* Add markers to the tests to be able to run them with MPI using `pytest-mpi` with the following command `mpirun -n 2 python -m pytest --with-mpi test_mumps.py `

The PR is for discussion as this repo is just a mirror

