### PR TITLE
Reset icntl[20] for dense RHS handling

### DIFF
--- a/src/mumps/mumps.py
+++ b/src/mumps/mumps.py
@@ -510,6 +510,7 @@ class Context:
                 )
 
             self.mumps_instance.set_dense_rhs(b)
+            self.mumps_instance.icntl[20] = 0  # in case sparse rhs was used before
         self.mumps_instance.job = 3
         self.call()
         if self.myid == 0:


### PR DESCRIPTION
Reset icntl[20] to 0 to handle previous sparse RHS.
Initial discussion here: https://github.com/akhmerov/python-mumps/pull/3#pullrequestreview-3625191501